### PR TITLE
fix: pass app object to open instead of string/array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -98,14 +98,13 @@ const startBrowserProcess = (browser, url, opts = {}, args = []) => {
     browser = undefined;
   }
 
-  // If there are arguments, they must be passed as array with the browser
-  if (typeof browser === 'string' && args.length > 0) {
-    browser = [browser].concat(args);
-  }
-
   // Fallback to opn
   // (It will always open new tab)
-  const options = {app: browser, url: true, wait: false, ...opts};
+  const options = {
+    app: {name: browser, arguments: args},
+    wait: false,
+    ...opts,
+  };
   return require('open')(url, options);
 };
 


### PR DESCRIPTION
Hello 👋 

Thank you for this package ❤️ 

It seems https://github.com/michaellzc/better-opn/commit/5a185c2d90c7a71548f8e7febb42d4e7d64ea849 broke the `open` invocation as it didn't update the structure of the arguments per https://github.com/sindresorhus/open/releases/tag/v8.0.0.

You can try this by writing a script that uses this library and set `BROWSER=firefox` to see.

This PR fixes the above issue.